### PR TITLE
Fix http server include errors

### DIFF
--- a/src/CGI/CGI.hpp
+++ b/src/CGI/CGI.hpp
@@ -13,12 +13,11 @@
 #ifndef CGI_HPP
 #define CGI_HPP
 
-#include "HttpServer/Structs/Response.hpp"
-#include "includes/Types.hpp"
 #include "includes/Webserv.hpp"
+#include "includes/Types.hpp"
 #include "src/ConfigParser/ConfigParser.hpp"
-#include "src/HttpServer/HttpServer.hpp"
 #include "src/Logger/Logger.hpp"
+#include "src/HttpServer/Structs/Response.hpp"
 
 class CGI {
   private:

--- a/src/HttpServer/Handlers/ChunkedReq.cpp
+++ b/src/HttpServer/Handlers/ChunkedReq.cpp
@@ -10,10 +10,10 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "src/HttpServer/HttpServer.hpp"
+#include "src/HttpServer/Structs/WebServer.hpp"
 #include "src/HttpServer/Structs/Connection.hpp"
 #include "src/HttpServer/Structs/Response.hpp"
-#include "src/HttpServer/Structs/WebServer.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 bool WebServer::processChunkSize(Connection *conn) {
 	size_t crlf_pos = findCRLF(conn->read_buffer);

--- a/src/HttpServer/Handlers/Connection.cpp
+++ b/src/HttpServer/Handlers/Connection.cpp
@@ -10,10 +10,10 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "src/HttpServer/Structs/Connection.hpp"
-#include "src/HttpServer/HttpServer.hpp"
-#include "src/HttpServer/Structs/Response.hpp"
 #include "src/HttpServer/Structs/WebServer.hpp"
+#include "src/HttpServer/Structs/Connection.hpp"
+#include "src/HttpServer/Structs/Response.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 void WebServer::handleNewConnection(ServerConfig *sc) {
 	struct sockaddr_in client_addr;

--- a/src/HttpServer/Handlers/DirectoryReq.cpp
+++ b/src/HttpServer/Handlers/DirectoryReq.cpp
@@ -10,10 +10,10 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "src/HttpServer/HttpServer.hpp"
+#include "src/HttpServer/Structs/WebServer.hpp"
 #include "src/HttpServer/Structs/Connection.hpp"
 #include "src/HttpServer/Structs/Response.hpp"
-#include "src/HttpServer/Structs/WebServer.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 // Serving the index file or listing if possible
 Response WebServer::handleDirectoryRequest(Connection *conn, const std::string &fullDirPath) {

--- a/src/HttpServer/Handlers/EpollEventHandler.cpp
+++ b/src/HttpServer/Handlers/EpollEventHandler.cpp
@@ -10,10 +10,10 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "src/HttpServer/HttpServer.hpp"
+#include "src/HttpServer/Structs/WebServer.hpp"
 #include "src/HttpServer/Structs/Connection.hpp"
 #include "src/HttpServer/Structs/Response.hpp"
-#include "src/HttpServer/Structs/WebServer.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 void WebServer::processEpollEvents(const struct epoll_event *events, int event_count) {
 	for (int i = 0; i < event_count; ++i) {

--- a/src/HttpServer/Handlers/Request.cpp
+++ b/src/HttpServer/Handlers/Request.cpp
@@ -10,10 +10,10 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "src/HttpServer/HttpServer.hpp"
+#include "src/HttpServer/Structs/WebServer.hpp"
 #include "src/HttpServer/Structs/Connection.hpp"
 #include "src/HttpServer/Structs/Response.hpp"
-#include "src/HttpServer/Structs/WebServer.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 /* Request handlers */
 

--- a/src/HttpServer/Handlers/ResponseHandler.cpp
+++ b/src/HttpServer/Handlers/ResponseHandler.cpp
@@ -10,10 +10,10 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "src/HttpServer/HttpServer.hpp"
+#include "src/HttpServer/Structs/WebServer.hpp"
 #include "src/HttpServer/Structs/Connection.hpp"
 #include "src/HttpServer/Structs/Response.hpp"
-#include "src/HttpServer/Structs/WebServer.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 ssize_t WebServer::prepareResponse(Connection *conn, const Response &resp) {
 	// TODO: some checks if the arguments are fine to work with

--- a/src/HttpServer/Handlers/ServerCGI.cpp
+++ b/src/HttpServer/Handlers/ServerCGI.cpp
@@ -10,10 +10,10 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "src/HttpServer/HttpServer.hpp"
+#include "src/HttpServer/Structs/WebServer.hpp"
 #include "src/HttpServer/Structs/Connection.hpp"
 #include "src/HttpServer/Structs/Response.hpp"
-#include "src/HttpServer/Structs/WebServer.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 void print_cgi_response(const std::string &cgi_output) {
 	std::istringstream response_stream(cgi_output);

--- a/src/HttpServer/ServerUtils.cpp
+++ b/src/HttpServer/ServerUtils.cpp
@@ -10,10 +10,10 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "HttpServer.hpp"
+#include "src/HttpServer/Structs/WebServer.hpp"
 #include "src/HttpServer/Structs/Connection.hpp"
 #include "src/HttpServer/Structs/Response.hpp"
-#include "src/HttpServer/Structs/WebServer.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 time_t WebServer::getCurrentTime() const { return time(NULL); }
 

--- a/src/HttpServer/Structs/Connection.cpp
+++ b/src/HttpServer/Structs/Connection.cpp
@@ -11,6 +11,8 @@
 /* ************************************************************************** */
 
 #include "Connection.hpp"
+#include "src/HttpServer/Structs/WebServer.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 Connection::Connection(int socket_fd)
     : fd(socket_fd),

--- a/src/HttpServer/Structs/Connection.hpp
+++ b/src/HttpServer/Structs/Connection.hpp
@@ -13,11 +13,12 @@
 #ifndef CONNECTION_HPP
 #define CONNECTION_HPP
 
+#include "includes/Webserv.hpp"
+#include "src/ConfigParser/ConfigParser.hpp"
 #include "Response.hpp"
-#include "WebServer.hpp"
-#include "src/HttpServer/HttpServer.hpp"
 
 class WebServer;
+class Response;
 
 /// Represents a client connection to the web server.
 ///

--- a/src/HttpServer/Structs/Response.hpp
+++ b/src/HttpServer/Structs/Response.hpp
@@ -13,9 +13,11 @@
 #ifndef RESPONSE_HPP
 #define RESPONSE_HPP
 
-#include "Connection.hpp"
-#include "WebServer.hpp"
-#include "src/HttpServer/HttpServer.hpp"
+#include "includes/Webserv.hpp"
+#include "src/Logger/Logger.hpp"
+#include "src/Utils/StringUtils.hpp"
+
+class Connection;
 
 class Response {
   public:

--- a/src/HttpServer/Structs/WebServer.cpp
+++ b/src/HttpServer/Structs/WebServer.cpp
@@ -11,6 +11,9 @@
 /* ************************************************************************** */
 
 #include "WebServer.hpp"
+#include "src/HttpServer/Structs/Connection.hpp"
+#include "src/HttpServer/Structs/Response.hpp"
+#include "src/HttpServer/HttpServer.hpp"
 
 bool WebServer::_running;
 static bool interrupted = false;

--- a/src/HttpServer/Structs/WebServer.hpp
+++ b/src/HttpServer/Structs/WebServer.hpp
@@ -16,6 +16,8 @@
 #include "Connection.hpp"
 #include "Response.hpp"
 #include "src/HttpServer/HttpServer.hpp"
+#include "src/Logger/Logger.hpp"
+#include "includes/Types.hpp"
 
 class ServerConfig; // Still needed to break potential circular dependencies
 class Connection;
@@ -259,8 +261,8 @@ class WebServer {
 	/// \returns Response object containing the requested resource or error.
 	Response handleReturnDirective(Connection *conn, uint16_t code, std::string target);
 
-	std::string getExtension(const std::string &path);
-	std::string detectContentType(const std::string &path);
+	static std::string getExtension(const std::string &path);
+	static std::string detectContentType(const std::string &path);
 
 	/* EpollEventHandler.cpp */
 


### PR DESCRIPTION
Fix include errors in `src/HttpServer` to resolve compilation issues.

This PR addresses cyclic and missing include dependencies within the `src/HttpServer` directory. Changes include simplifying header inclusions, adding forward declarations, decoupling `Response.cpp` from `WebServer` by making `detectContentType` and `getExtension` static and introducing local MIME helpers, and adjusting include orders to ensure correct compilation.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1be71ff-17d5-4fde-817b-ffa34626b4bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1be71ff-17d5-4fde-817b-ffa34626b4bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

